### PR TITLE
KeyedInMemoryLock cleans up after itself

### DIFF
--- a/source/Directory.Packages.props
+++ b/source/Directory.Packages.props
@@ -4,7 +4,7 @@
     <CentralPackageVersionOverrideEnabled>false</CentralPackageVersionOverrideEnabled>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="AsyncKeyedLock" Version="7.1.8" />
+    <PackageVersion Include="AsyncKeyedLock" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />

--- a/source/Directory.Packages.props
+++ b/source/Directory.Packages.props
@@ -4,6 +4,7 @@
     <CentralPackageVersionOverrideEnabled>false</CentralPackageVersionOverrideEnabled>
   </PropertyGroup>
   <ItemGroup>
+    <PackageVersion Include="AsyncKeyedLock" Version="7.1.8" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />

--- a/source/TransactionalBox/Internals/InternalPackages/KeyedInMemoryLock/InternalKeyedInMemoryLock.cs
+++ b/source/TransactionalBox/Internals/InternalPackages/KeyedInMemoryLock/InternalKeyedInMemoryLock.cs
@@ -1,18 +1,14 @@
-﻿using System.Collections.Concurrent;
+﻿using AsyncKeyedLock;
 
 namespace TransactionalBox.Internals.InternalPackages.KeyedInMemoryLock
 {
     internal sealed class InternalKeyedInMemoryLock : IKeyedInMemoryLock
     {
-        private static ConcurrentDictionary<string, SemaphoreSlim> _locks = new ConcurrentDictionary<string, SemaphoreSlim>();
+        private static readonly AsyncKeyedLocker<string> _locks = new();
 
         public async Task<ILockInstance> Acquire(string key, CancellationToken cancellationToken = default)
         {
-            var @lock = _locks.GetOrAdd(key, x => new SemaphoreSlim(1, 1));
-
-            await @lock.WaitAsync(cancellationToken);
-
-            return new LockInstance(@lock);
+            return new LockInstance(await _locks.LockAsync(key, cancellationToken));
         }
     }
 }

--- a/source/TransactionalBox/Internals/InternalPackages/KeyedInMemoryLock/LockInstance.cs
+++ b/source/TransactionalBox/Internals/InternalPackages/KeyedInMemoryLock/LockInstance.cs
@@ -1,11 +1,11 @@
 ﻿namespace TransactionalBox.Internals.InternalPackages.KeyedInMemoryLock
 {
-    internal sealed class LockInstance : ILockInstance
+    internal readonly struct LockInstance : ILockInstance
     {
-        private readonly SemaphoreSlim _semaphoreSlim;
+        private readonly IDisposable _instance;
 
-        internal LockInstance(SemaphoreSlim semaphoreSlim) => _semaphoreSlim = semaphoreSlim;
+        internal LockInstance(IDisposable instance) => _instance = instance;
 
-        public void Dispose() => _semaphoreSlim.Release();
+        public void Dispose() => _instance.Dispose();
     }
 }

--- a/source/TransactionalBox/TransactionalBox.csproj
+++ b/source/TransactionalBox/TransactionalBox.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
+    <PackageReference Include="AsyncKeyedLock" />
     <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />


### PR DESCRIPTION
...and uses pooled SemaphoreSlim instances